### PR TITLE
Remove startup code settings

### DIFF
--- a/rpi/configs/batocera/config.txt
+++ b/rpi/configs/batocera/config.txt
@@ -9,10 +9,6 @@ arm_64bit=1
 kernel=boot/linux
 initramfs boot/initrd.lz4
 
-# Firmware configurations
-start_file=start4.elf
-fixup_file=fixup4.dat
-
 # Sets the initial CEC name of the device
 cec_osd_name=batocera
 


### PR DESCRIPTION
This should be selected automatically AFAIK and the current setting prevents a Zero2W from booting.

PS: I have no Pi4 (neither a CM4 or anything else) to check if this is correct for those, but it seems most `config.txt` omit those settings and the correct boot code is selected by the loader...